### PR TITLE
Add custom date as filter scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ If you want to change the configuration, you can add the following to an initial
 
 ```ruby
 SolidusAbandonedCarts::Config.tap do |config|
-  # Amount of time after which a cart is considered abandoned.
-  config.abandoned_timeout = 24.hours
+  # Amount of day(s) after which a cart is considered abandoned.
+  config.abandoned_timeout = 1
+
+  # Amount of day(s) before which a cart is considered abandoned.
+  config.abandoned_date = 20
 
   # The states in which a cart is considered to be abandoned.
   config.abandoned_states = [:cart, :address, :delivery, :payment, :confirm]

--- a/app/decorators/models/spree/order_decorator.rb
+++ b/app/decorators/models/spree/order_decorator.rb
@@ -4,11 +4,13 @@ module SolidusAbandonedCarts
   module Spree
     module OrderDecorator
       def self.prepended(base)
-        base.scope :abandoned, ->(time = Time.current - SolidusAbandonedCarts::Config.abandoned_timeout) do
+        base.scope :abandoned, ->(
+          date = (DateTime.now - SolidusAbandonedCarts::Config.abandoned_date.to_i.days) - SolidusAbandonedCarts::Config.abandoned_timeout.to_i.days
+        ) do
           incomplete.
             where('email IS NOT NULL').
             where('item_count > 0').
-            where('updated_at < ?', time)
+            where('updated_at < ?', date)
         end
 
         base.scope :abandon_not_notified, -> { abandoned.where(abandoned_cart_email_sent_at: nil) }

--- a/lib/solidus_abandoned_carts/configuration.rb
+++ b/lib/solidus_abandoned_carts/configuration.rb
@@ -3,7 +3,8 @@
 module SolidusAbandonedCarts
   class Configuration < Spree::Preferences::Configuration
     preference :abandoned_states, :array, default: %i[cart address delivery payment confirm]
-    preference :abandoned_timeout, :time, default: 24.hours
+    preference :abandoned_timeout, :integer, default: 1
+    preference :abandoned_date, :integer, default: 0
 
     class_name_attribute :mailer_class, default: 'Spree::AbandonedCartMailer'
     class_name_attribute :notifier_class, default: 'Spree::AbandonedCartNotifier'


### PR DESCRIPTION
Description:

- Move logic considering `days` instead of `hours`
- Add `abandoned_date` setting