### PR TITLE
Remove solidus_dev_support from engine.rb

### DIFF
--- a/lib/solidus_abandoned_carts/engine.rb
+++ b/lib/solidus_abandoned_carts/engine.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'solidus_dev_support'
 require 'spree/core'
 
 module SolidusAbandonedCarts


### PR DESCRIPTION
The engine class should not require a dev dependency. The solidus_dev_support
dependency is declared in https://github.com/solidusio-contrib/solidus_abandoned_carts/blob/master/solidus_abandoned_carts.gemspec#L36

The require breaks projects that have updated or installed the extension.