### PR TITLE
Add retroactivity configuration

### DIFF
--- a/app/decorators/models/spree/order_decorator.rb
+++ b/app/decorators/models/spree/order_decorator.rb
@@ -11,7 +11,16 @@ module SolidusAbandonedCarts
             where('updated_at < ?', time)
         end
 
-        base.scope :abandon_not_notified, -> { abandoned.where(abandoned_cart_email_sent_at: nil) }
+        base.scope :abandon_not_notified, -> do
+          relation = abandoned.where(abandoned_cart_email_sent_at: nil)
+
+          if SolidusAbandonedCarts::Config.abandoned_retroactivity
+            retroactivity = Time.current - SolidusAbandonedCarts::Config.abandoned_retroactivity
+            relation = relation.where('updated_at > ?', retroactivity)
+          end
+
+          relation
+        end
       end
 
       def last_for_user?

--- a/lib/generators/solidus_abandoned_carts/install/install_generator.rb
+++ b/lib/generators/solidus_abandoned_carts/install/install_generator.rb
@@ -3,6 +3,8 @@
 module SolidusAbandonedCarts
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
       class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_migrations
@@ -16,6 +18,10 @@ module SolidusAbandonedCarts
         else
           puts 'Skipping rake db:migrate, don\'t forget to run it!' # rubocop:disable Rails/Output
         end
+      end
+
+      def copy_initializer
+        copy_file 'initializer.rb', 'config/initializers/solidus_abandoned_carts.rb'
       end
     end
   end

--- a/lib/generators/solidus_abandoned_carts/install/templates/initializer.rb
+++ b/lib/generators/solidus_abandoned_carts/install/templates/initializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+SolidusAbandonedCarts::Config.tap do |config|
+  # Override timeout which make an order abandoned
+  # config.abandoned_timeout = 24.hours
+
+  # Override the abandoned states
+  # config.abandoned_states = %i[cart address delivery payment confirm]
+
+  # Override the time which restricts the abandoned orders
+  # avoiding that the older ones aren't considered abandoned.
+  # Can be set to nil to remove this restriction
+  config.abandoned_retroactivity = 1.month
+
+  # Override mailer classes
+  # config.mailer_class = 'Spree::AbandonedCartMailer'
+  # config.notifier_class = 'Spree::AbandonedCartNotifier'
+
+  # Override job classes
+  # config.notifier_job_class = 'Spree::NotifyAbandonedCartJob'
+  # config.schedule_job_class = 'Spree::ScheduleAbandonedCartsJob'
+end

--- a/lib/solidus_abandoned_carts/configuration.rb
+++ b/lib/solidus_abandoned_carts/configuration.rb
@@ -4,6 +4,7 @@ module SolidusAbandonedCarts
   class Configuration < Spree::Preferences::Configuration
     preference :abandoned_states, :array, default: %i[cart address delivery payment confirm]
     preference :abandoned_timeout, :time, default: 24.hours
+    preference :abandoned_retroactivity, :time, default: nil
 
     class_name_attribute :mailer_class, default: 'Spree::AbandonedCartMailer'
     class_name_attribute :notifier_class, default: 'Spree::AbandonedCartNotifier'


### PR DESCRIPTION
Ref: #17 

Set the retroactivity limit avoiding that an application that works for a long time sends emails to a very old abandoned cart.

#### QA (Default configuration: `abandoned timeout`: 24.hours and `abandoned_retroactivity`:  1.month)

When the order `updated_at` is set to `Time.now` - no abandoned order

![image](https://user-images.githubusercontent.com/9986708/74527426-f15cda80-4f25-11ea-92dd-2dfc278e52d3.png)

When the order `updated_at` is set to `Time.now - 1.day` - abandoned order

![image](https://user-images.githubusercontent.com/9986708/74527534-4567bf00-4f26-11ea-9edc-09bb41144e29.png)

When the order `updated_at` is set to `Time.now - 1.month` - no abandoned order

![image](https://user-images.githubusercontent.com/9986708/74527591-6cbe8c00-4f26-11ea-8c7d-7d21e9d52608.png)
