### PR TITLE
improve performance of abandoned cart notification

### DIFF
--- a/app/decorators/models/solidus_abandoned_carts/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_abandoned_carts/spree/order_decorator.rb
@@ -4,19 +4,28 @@ module SolidusAbandonedCarts
   module Spree
     module OrderDecorator
       def self.prepended(base)
-        base.scope :abandoned, ->(time = Time.current - SolidusAbandonedCarts::Config.abandoned_timeout) do
-          incomplete.
-            where('email IS NOT NULL').
-            where('item_count > 0').
-            where('updated_at < ?', time)
+        base.scope :abandoned, -> (time = Time.current - SolidusAbandonedCarts::Config.abandoned_timeout) do
+          selected_orders =
+            incomplete
+            .where('item_count > 0')
+            .where('updated_at < ?', time)
+            .where.not(email: nil)
+            .group(:email)
+            .select(:email, 'MAX(updated_at) AS updated_at')
+
+          joins(<<~SQL.squish)
+            INNER JOIN (#{selected_orders.to_sql}) AS so
+              ON spree_orders.email = so.email
+              AND spree_orders.updated_at = so.updated_at
+          SQL
         end
 
         base.scope :abandon_not_notified, -> do
           relation = abandoned.where(abandoned_cart_email_sent_at: nil)
 
-          if SolidusAbandonedCarts::Config.abandoned_retroactivity
-            retroactivity = Time.current - SolidusAbandonedCarts::Config.abandoned_retroactivity
-            relation = relation.where('updated_at > ?', retroactivity)
+          if SolidusAbandonedCarts::Config.abandoned_max_timeout
+            retroactivity = Time.current - SolidusAbandonedCarts::Config.abandoned_max_timeout
+            relation = relation.where('spree_orders.updated_at > ?', retroactivity)
           end
 
           relation

--- a/app/jobs/spree/schedule_abandoned_carts_job.rb
+++ b/app/jobs/spree/schedule_abandoned_carts_job.rb
@@ -6,9 +6,7 @@ module Spree
 
     def perform
       Spree::Order.abandon_not_notified.find_each do |order|
-        next unless order.last_for_user?
-
-        SolidusAbandonedCarts::Config.notifier_job_class.perform_later(order)
+        SolidusAbandonedCarts::Config.notifier_class.new(order).call(:deliver_later)
       end
     end
   end

--- a/app/services/spree/abandoned_cart_notifier.rb
+++ b/app/services/spree/abandoned_cart_notifier.rb
@@ -6,10 +6,10 @@ module Spree
       @order = order
     end
 
-    def call
+    def call(delivery = :deliver_now)
       return if order.abandoned_cart_email_sent_at
 
-      SolidusAbandonedCarts::Config.mailer_class.abandoned_cart_email(order).deliver_now
+      SolidusAbandonedCarts::Config.mailer_class.abandoned_cart_email(order).send(delivery)
 
       order.touch(:abandoned_cart_email_sent_at)
     end

--- a/db/migrate/202101261212121_add_abandoned_cart_indexes_to_spree_orders.rb
+++ b/db/migrate/202101261212121_add_abandoned_cart_indexes_to_spree_orders.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddAbandonedCartIndexesToSpreeOrders < SolidusSupport::Migration[5.1]
+  def change
+    add_index :spree_orders, [:email, :updated_at]
+    add_index :spree_orders, :updated_at, where: <<~SQL.squish
+      email IS NOT NULL
+      AND completed_at IS NULL
+      AND item_count > 0
+    SQL
+  end
+end

--- a/db/migrate/202101261212121_add_abandoned_cart_indexes_to_spree_orders.rb
+++ b/db/migrate/202101261212121_add_abandoned_cart_indexes_to_spree_orders.rb
@@ -3,10 +3,15 @@
 class AddAbandonedCartIndexesToSpreeOrders < SolidusSupport::Migration[5.1]
   def change
     add_index :spree_orders, [:email, :updated_at]
-    add_index :spree_orders, :updated_at, where: <<~SQL.squish
-      email IS NOT NULL
-      AND completed_at IS NULL
-      AND item_count > 0
-    SQL
+
+    if ActiveRecord::Base.connection.adapter_name == 'MySQL'
+      add_index :spree_orders, [:updated_at, :email, :completed_at, :item_count]
+    else
+      add_index :spree_orders, :updated_at, where: <<~SQL.squish
+        email IS NOT NULL
+        AND completed_at IS NULL
+        AND item_count > 0
+      SQL
+    end
   end
 end

--- a/lib/generators/solidus_abandoned_carts/install/templates/initializer.rb
+++ b/lib/generators/solidus_abandoned_carts/install/templates/initializer.rb
@@ -10,7 +10,7 @@ SolidusAbandonedCarts::Config.tap do |config|
   # Override the time which restricts the abandoned orders
   # avoiding that the older ones aren't considered abandoned.
   # Can be set to nil to remove this restriction
-  config.abandoned_retroactivity = 1.month
+  config.abandoned_max_timeout = 1.month
 
   # Override mailer classes
   # config.mailer_class = 'Spree::AbandonedCartMailer'

--- a/lib/solidus_abandoned_carts/configuration.rb
+++ b/lib/solidus_abandoned_carts/configuration.rb
@@ -4,7 +4,9 @@ module SolidusAbandonedCarts
   class Configuration < Spree::Preferences::Configuration
     preference :abandoned_states, :array, default: %i[cart address delivery payment confirm]
     preference :abandoned_timeout, :time, default: 24.hours
-    preference :abandoned_retroactivity, :time, default: nil
+    preference :abandoned_max_timeout, :time, default: 1.week
+
+    alias abandoned_retroactivity abandoned_max_timeout
 
     class_name_attribute :mailer_class, default: 'Spree::AbandonedCartMailer'
     class_name_attribute :notifier_class, default: 'Spree::AbandonedCartNotifier'

--- a/spec/lib/tasks/solidus_abandoned_carts/send_notification_rake_spec.rb
+++ b/spec/lib/tasks/solidus_abandoned_carts/send_notification_rake_spec.rb
@@ -1,31 +1,35 @@
 # frozen_string_literal: true
 
 RSpec.describe 'solidus_abandoned_carts:send_notification' do
-  let(:user) { create(:user) }
-  let!(:order1) do
-    order = create(:order_with_line_items, user: user)
-    order.update_attributes(updated_at: (Time.current - 48.hours),
-                            abandoned_cart_email_sent_at: nil)
-    order
-  end
-  let!(:order2) do
-    order = create(:order_with_line_items, user: user)
-    order.update_attributes(updated_at: (Time.current - 48.hours),
-                            abandoned_cart_email_sent_at: nil)
-    order
+  let(:user) { create :user }
+
+  let!(:order_a) do
+    create :order, item_count: 1, user: user, email: user.email,
+      abandoned_cart_email_sent_at: nil, updated_at: 50.hours.ago
   end
 
-  context 'perform' do
+  let!(:order_b) do
+    create :order, item_count: 1, user: user, email: user.email,
+      abandoned_cart_email_sent_at: nil, updated_at: 48.hours.ago
+  end
+
+  before { clear_enqueued_jobs }
+
+  describe '#perform' do
     include_context(
       'rake',
       task_path: 'lib/tasks/solidus_abandoned_carts/send_notification.rake',
       task_name: 'solidus_abandoned_carts:send_notification',
     )
 
-    it 'runs' do
-      expect { task.invoke }.to output(
-        "Sending abandoned carts notifications...\nnotifications sent: 1\nDone!\n"
-      ).to_stdout
+    it 'will send abandoned cart emails' do
+      task.invoke
+
+      expect(ActionMailer::Base.deliveries.size).to be 0
+      expect(enqueued_jobs.size).to be 1
+
+      expect(order_a.reload.abandoned_cart_email_sent_at).to be_nil
+      expect(order_b.reload.abandoned_cart_email_sent_at).not_to be_nil
     end
   end
 end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Spree::Order do
     end
 
     let!(:second_abandoned_order) do
-      # Abandoned but too old with retroactivity set
+      # Abandoned but too old with max_timeout set
       create(
         :order,
         updated_at: abandoned_timeout - 1.month,
@@ -61,7 +61,7 @@ RSpec.describe Spree::Order do
     let(:abandoned_timeout) { Time.current - SolidusAbandonedCarts::Config.abandoned_timeout - 1.second }
 
     before do
-      stub_spree_preferences(SolidusAbandonedCarts::Config, abandoned_retroactivity: abandoned_retroactivity)
+      stub_spree_preferences(SolidusAbandonedCarts::Config, abandoned_max_timeout: abandoned_max_timeout)
 
       # Abandoned but notified
       create(
@@ -72,16 +72,16 @@ RSpec.describe Spree::Order do
       )
     end
 
-    context 'when the retroactivity configuration is set' do
-      let(:abandoned_retroactivity) { 1.month }
+    context 'when the max_timeout configuration is set' do
+      let(:abandoned_max_timeout) { 1.month }
 
       it 'returns orders that are abandoned and not notified' do
         expect(described_class.abandon_not_notified).to match_array([first_abandoned_order])
       end
     end
 
-    context 'when the retroactivity configuration is not set' do
-      let(:abandoned_retroactivity) { nil }
+    context 'when the max_timeout configuration is not set' do
+      let(:abandoned_max_timeout) { nil }
 
       it 'returns orders that are abandoned and not notified' do
         expect(described_class.abandon_not_notified).to match_array([first_abandoned_order, second_abandoned_order])


### PR DESCRIPTION
This is a good library, but it needs some performance tuning. First, iterating over all of the orders with no index and then doing a direct call for each individual order isn't good for performance. The next problem was that I "noticed" there was no max timeout - but instead it was called retroactivity. Not sure why it (a) defaulted to `nil` and (b) had an irregular name but I have renamed it `max_timeout`, aliased the previous method to it, and default set it to 1 week ago.

Next goal was to merge the `Spree::Order#last_for_user?` into the filters. We do this by grabbing all the data like normal, then grouping by email and selecting the max updated at. Then we look inside the orders table again through a self inner join and grabbing the full record to be used. This retains current behaviour and improves the performance. On a large database we can get 50ms out of it. When we add two indexes (one for the subquery and one for the main query) we get the performance down to 3ms.

When iterating over all of the orders, if there is an error delivering the email, the job will exit and it will _not_ touch the timestamp and will hold up the iteration. To get around this, we put it in a deliver later job and touch the timestamp even if the email fails to send.

This is essentially the new SQL that will run:

```sql
SELECT o.*
FROM spree_orders AS o
INNER JOIN (
  SELECT email, MAX(updated_at) AS updated_at
  FROM spree_orders
  WHERE email IS NOT NULL
    AND completed_at IS NULL
    AND item_count > 0
    AND updated_at BETWEEN NOW() - INTERVAL '7 days' AND NOW() - INTERVAL '24 hours'
  GROUP BY email
) AS so
  ON o.email = so.email
  AND o.updated_at = so.updated_at;
```

Without any indexes:

```
Hash Join  (cost=5610.60..10051.43 rows=1 width=227) (actual time=30.087..56.917 rows=479 loops=1)
  Hash Cond: (((a.email)::text = (spree_orders.email)::text) AND (a.updated_at = (max(spree_orders.updated_at))))
  ->  Seq Scan on spree_orders a  (cost=0.00..3899.36 rows=103136 width=227) (actual time=0.003..9.198 rows=103137 loops=1)
  ->  Hash  (cost=5602.62..5602.62 rows=532 width=30) (actual time=28.714..28.715 rows=479 loops=1)
        Buckets: 1024  Batches: 1  Memory Usage: 39kB
        ->  Finalize GroupAggregate  (cost=5549.46..5597.30 rows=532 width=30) (actual time=27.909..28.548 rows=479 loops=1)
              Group Key: spree_orders.email
              ->  Gather Merge  (cost=5549.46..5590.41 rows=315 width=30) (actual time=27.902..28.366 rows=487 loops=1)
                    Workers Planned: 1
                    Workers Launched: 1
                    ->  Partial GroupAggregate  (cost=4549.45..4554.96 rows=315 width=30) (actual time=25.780..25.949 rows=244 loops=2)
                          Group Key: spree_orders.email
                          ->  Sort  (cost=4549.45..4550.24 rows=315 width=30) (actual time=25.774..25.798 rows=249 loops=2)
                                Sort Key: spree_orders.email
                                Sort Method: quicksort  Memory: 43kB
                                Worker 0:  Sort Method: quicksort  Memory: 45kB
                                ->  Parallel Seq Scan on spree_orders  (cost=0.00..4536.38 rows=315 width=30) (actual time=1.307..25.235 rows=249 loops=2)
                                      Filter: ((email IS NOT NULL) AND (completed_at IS NULL) AND (item_count > 0) AND (updated_at >= (now() - '7 days'::interval)) AND (updated_at <= (now() - '24:00:00'::interval)))
                                      Rows Removed by Filter: 51320
Planning Time: 0.287 ms
Execution Time: 57.057 ms
```

With indexes:

```
Nested Loop  (cost=286.19..3918.49 rows=1 width=227) (actual time=0.652..3.710 rows=479 loops=1)
  ->  HashAggregate  (cost=285.78..291.10 rows=532 width=30) (actual time=0.639..0.725 rows=479 loops=1)
        Group Key: spree_orders.email
        ->  Index Scan using abandoned_carts_spree_orders_temp on spree_orders  (cost=0.30..283.10 rows=535 width=30) (actual time=0.050..0.428 rows=498 loops=1)
              Index Cond: ((updated_at >= (now() - '7 days'::interval)) AND (updated_at <= (now() - '24:00:00'::interval)))
  ->  Index Scan using abandoned_carts_spree_orders_temp_email_updated_at on spree_orders a  (cost=0.42..6.80 rows=1 width=227) (actual time=0.005..0.006 rows=1 loops=479)
        Index Cond: (((email)::text = (spree_orders.email)::text) AND (updated_at = (max(spree_orders.updated_at))))
Planning Time: 0.784 ms
Execution Time: 3.782 ms
```