### PR TITLE
require rspec/rails before support files

### DIFF
--- a/lib/solidus_abandoned_carts/engine.rb
+++ b/lib/solidus_abandoned_carts/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusAbandonedCarts
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace Spree
 

--- a/spec/lib/tasks/solidus_abandoned_carts/send_notification_rake_spec.rb
+++ b/spec/lib/tasks/solidus_abandoned_carts/send_notification_rake_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe 'solidus_abandoned_carts:send_notification' do
   let(:user) { create(:user) }
   let!(:order1) do
     order = create(:order_with_line_items, user: user)
-    order.update_attributes(updated_at: (Time.current - 48.hours),
+    order.update(updated_at: (Time.current - 48.hours),
                             abandoned_cart_email_sent_at: nil)
     order
   end
   let!(:order2) do
     order = create(:order_with_line_items, user: user)
-    order.update_attributes(updated_at: (Time.current - 48.hours),
+    order.update(updated_at: (Time.current - 48.hours),
                             abandoned_cart_email_sent_at: nil)
     order
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,12 +11,9 @@ require File.expand_path('dummy/config/environment.rb', __dir__)
 # Requires factories and other useful helpers defined in spree_core.
 require 'solidus_dev_support/rspec/feature_helper'
 
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
+require 'rspec/rails'
 
-# Requires factories defined in lib/solidus_abandoned_carts/factories.rb
-# require 'solidus_abandoned_carts/factories'
+Dir[File.join(File.dirname(__FILE__), '/support/**/*.rb')].each { |file| require file }
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
This extension now passes against specs for `2.9`, `2.10`, `2.11`, and `3.0`