### PR TITLE
Update gemspec to allow Solidus 3

### DIFF
--- a/solidus_abandoned_carts.gemspec
+++ b/solidus_abandoned_carts.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'deface', '~> 1.0'
-  s.add_dependency 'solidus', ['>= 2.0.0', '< 3']
+  s.add_dependency 'solidus', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', '~> 0.5'
 
   s.add_development_dependency 'solidus_dev_support'


### PR DESCRIPTION
## Description

This is needed because the last version of Solidus is 3.0