### PR TITLE
Relax solidus gem dependency

### DIFF
--- a/solidus_abandoned_carts.gemspec
+++ b/solidus_abandoned_carts.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'deface', '~> 1.0'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', '~> 0.5'
 

--- a/solidus_abandoned_carts.gemspec
+++ b/solidus_abandoned_carts.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'deface', '~> 1.0'
-  s.add_dependency 'solidus', ['>= 2.0.0', '< 4']
+  s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', '~> 0.5'
 
   s.add_development_dependency 'solidus_dev_support'


### PR DESCRIPTION
Relax solidus dependency to use `solidus_core` gem instead of `solidus` gem.
Removed `deface` gem dependency for no use in the project.